### PR TITLE
dns-sd fix

### DIFF
--- a/app.cfg
+++ b/app.cfg
@@ -3,11 +3,11 @@
 # The ssh user name on remote server
 REMOTEUSER="TimeMachine" 
 
-# The ssh user password on remote server
+# The name of remote server
 REMOTEHOST="nas.home.martinreinhardt-online.de" 
 
 # The label for the service, that's registered with dns-sd
-LABEL="Time Machine-Backups"
+LABEL="Time-Machine-Backups"
 # examples: "DiskStation" (Synology), "Time Machine-Backups" (QNAP)
 
 # The path to the used ssh key file


### PR DESCRIPTION
Hi, please see the commit comment but there is a dash missing in the LABEL variable that causes dns-sd to fail with "DNSService call failed -65540"
